### PR TITLE
Put a try / except block into image import. This will catch URLs that…

### DIFF
--- a/wordpress2puput/management/commands/wp2puput.py
+++ b/wordpress2puput/management/commands/wp2puput.py
@@ -251,7 +251,7 @@ class Command(LabelCommand):
                 image.flush()
                 return image
         except requests.exceptions.ConnectionError:
-            print('WARNING: Unable to connect to URL "{}". Image will be broken.'.format(image_url))
+            self.stdout.write('WARNING: Unable to connect to URL "{}". Image will be broken.'.format(image_url))
         return
 
     def import_header_image(self, entry, items, image_id):

--- a/wordpress2puput/management/commands/wp2puput.py
+++ b/wordpress2puput/management/commands/wp2puput.py
@@ -244,11 +244,14 @@ class Command(LabelCommand):
 
     def _import_image(self, image_url):
         image = NamedTemporaryFile(delete=True)
-        response = requests.get(image_url)
-        if response.status_code == 200:
-            image.write(response.content)
-            image.flush()
-            return image
+        try:
+            response = requests.get(image_url)
+            if response.status_code == 200:
+                image.write(response.content)
+                image.flush()
+                return image
+        except requests.exceptions.ConnectionError:
+            print('WARNING: Unable to connect to URL "{}". Image will be broken.'.format(image_url))
         return
 
     def import_header_image(self, entry, items, image_id):


### PR DESCRIPTION
… no longer exist, and print a console warning to the user that the image can not be imported because the URL no longer exists instead of erroring.