### PR TITLE
Use the original WP post slug if possible.

### DIFF
--- a/wordpress2puput/management/commands/wp2puput.py
+++ b/wordpress2puput/management/commands/wp2puput.py
@@ -200,7 +200,11 @@ class Command(LabelCommand):
         excerpt = strip_tags(item_node.find(u'{{{0:s}excerpt/}}encoded'.format(self.WP_NS)).text or '')
         if not excerpt and content:
             excerpt = Truncator(content).words(50)
-        slug = slugify(title)[:255] or u'post-{0:s}'.format(item_node.find(u'{{{0:s}}}post_id'.format(self.WP_NS)).text)
+        slug = (
+            item_node.find(u'{{{0:s}}}post_name'.format(self.WP_NS)).text
+            or slugify(title)[:255]
+            or u'post-{0:s}'.format(item_node.find(u'{{{0:s}}}post_id'.format(self.WP_NS)).text)
+        )
         creator = item_node.find('{http://purl.org/dc/elements/1.1/}creator').text
         try:
             entry_date = datetime.strptime(item_node.find(u'{{{0:s}}}post_date_gmt'.format(self.WP_NS)).text,


### PR DESCRIPTION
When importing from Wordpress, it might be important to preserve post URLs, and since the slug is involved, this could improve on that front.